### PR TITLE
Count results does not reflect actual state due to query cache

### DIFF
--- a/src/Merlosy/MongoDatatables/MongoDatatables.php
+++ b/src/Merlosy/MongoDatatables/MongoDatatables.php
@@ -121,7 +121,7 @@ class MongoDatatables extends Datatables {
         $myQuery = clone $query;
 
         if ( $this->query_type == 'moloquent' ) {
-            $this->$count = $myQuery->setBindings($myQuery->getBindings())->remember(1)->count();
+            $this->$count = $myQuery->setBindings($myQuery->getBindings())->count();
         }
         else {
 
@@ -163,7 +163,7 @@ class MongoDatatables extends Datatables {
 
             $this->$count = DB::connection($connection)
             ->table(DB::raw('('.$myQuery->toSql().') AS count_row_table'))
-            ->setBindings($myQuery->getBindings())->remember(1)->count();
+            ->setBindings($myQuery->getBindings())->count();
         }
 
     }


### PR DESCRIPTION
Most of the time count() is expected to give real-time results. One minute cache gives unexpected results.
